### PR TITLE
Feature: autodrop channel

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            // "preLaunchTask": "build",
+            "program": "${workspaceFolder}/src/Server/bin/Debug/netcoreapp2.0/fschathost.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "console": "internalConsole",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/readme.md
+++ b/readme.md
@@ -32,9 +32,15 @@ Sample chat application built with netcore, F#, Akka.net and Fable.
 
 ## Running integration (e2e) tests
 
-* Start the server
+* Follow the instructions above to start the server
 * **Move to `test/e2e` folder**: `cd test\e2e`
 * run the tests: `dotnet run`
+
+or, if you love VS Code as much as I do:
+
+* open Integrated Terminal (`Ctrl-~` keyboard shortcut)
+* start server by typing `dev-server` (this is for Windows, on Linux it should be `cd src/Server & dotnet run`)
+* press F1 and start typing `Expecto`, choose `Expecto: Run` in the dropdown
 
 ## Implementation overview
 

--- a/src/Client/NavMenu/View.fs
+++ b/src/Client/NavMenu/View.fs
@@ -14,7 +14,7 @@ let menuItem htmlProp name topic isCurrent =
     button
       [ classList [ "btn", true; "fs-channel", true; "selected", isCurrent ]
         htmlProp ]
-      [ str name
+      [ h1 [] [str name]
         span [] [str topic]]
 
 let menuItemChannel (ch: ChannelInfo) currentPage = 

--- a/src/Client/sass/menu.scss
+++ b/src/Client/sass/menu.scss
@@ -132,14 +132,19 @@
 	height: 50px;
 	padding: 5px 15px;
 
+	color: $color-menu-fg;
+	border-radius: 0;
+
 	text-align: left;
 	white-space: nowrap;
 	text-overflow: ellipsis;
 
-	color: $color-menu-fg;
-	border-radius: 0;
+	> h1 {
+		line-height: 20px;
+		margin: 0;
 
-	line-height: 20px;
+		font-size: $font-size;
+	}
 
 	> span {
 		display: block;
@@ -147,7 +152,7 @@
 
 		white-space: nowrap;
 		text-overflow: ellipsis;
-
+	
 		opacity: .62;
 
 		font-size: $font-size-sm;

--- a/src/Server/ChatServer.fs
+++ b/src/Server/ChatServer.fs
@@ -39,7 +39,7 @@ and ServerNotifyMessage =
 type ServerControlMessage =
     | UpdateState of (ServerData -> ServerData)
     | FindChannel of (ChannelData -> bool)
-    | GetOrCreateChannel of name: string
+    | GetOrCreateChannel of name: string * topic: string * config: ChannelConfig
     | ListChannels of (ChannelData -> bool)
 
     | StartSession of UserId * IActorRef<ServerNotifyMessage>
@@ -52,6 +52,8 @@ type ServerReplyMessage =
     | FoundChannels of ChannelData list
 
 type ServerT = IActorRef<ServerControlMessage>
+
+let private initialState = { channels = []; sessions = Map.empty }
 
 module internal Helpers =
 
@@ -69,7 +71,7 @@ module internal Helpers =
     let __lastid = ref 100
     let newId () = System.Threading.Interlocked.Increment __lastid
 
-module ServerApi =
+module private Implementation =
     open Helpers
 
     /// Creates a new channel or returns existing if channel already exists
@@ -79,71 +81,92 @@ module ServerApi =
             Ok (state, chan)
         | _ when isValidName name ->
             let channelActor = createChannel ()
-            let newChan = {
-                id = ChannelId (newId()); name = name; topic = topic; channelActor = channelActor }
+            let newChan = {id = ChannelId (newId()); name = name; topic = topic; channelActor = channelActor }
 
             do state.sessions |> Map.iter(fun _ session -> session.notifySink <! AddChannel newChan)
             Ok ({state with channels = newChan::state.channels}, newChan)
         | _ ->
             Result.Error "Invalid channel name"
 
-    let addSub userId notifySink (state: ServerData) =
-        { state with sessions = state.sessions |> Map.add userId { notifySink = notifySink } }
-    let dropSub userId (state: ServerData) =
-        { state with sessions = state.sessions |> Map.remove userId }
-
     let setTopic chanId newTopic state =
         Ok (state |> updateChannel (fun chan -> {chan with topic = newTopic}) chanId)
 
-/// Starts IRC server actor.
-let startServer (system: ActorSystem) =
+    let getChannelImpl message (server: ServerT) =
+        async {
+            let! (reply: ServerReplyMessage) = server <? message
+            match reply with
+            | FoundChannel channel -> return Ok channel
+            | RequestError error -> return Result.Error error
+            | _ -> return Result.Error "Unknown reason"
+        }
 
-    let rec behavior (state: ServerData) (ctx: Actor<ServerControlMessage>) =
+let startServer (system: ActorSystem) : IActorRef<ServerControlMessage> =
+
+    let rec serverBehavior (state: ServerData) (ctx: Actor<obj>): obj -> Effect<_> =
         let replyAndUpdate f = function
-            | Ok (newState, reply) -> ctx.Sender() <! f reply; become (behavior newState ctx)
-            | Result.Error errtext -> ctx.Sender() <! RequestError errtext; ignored state
+            | Ok (newState, reply) -> ctx.Sender() <! f reply; become (serverBehavior newState ctx)
+            | Result.Error errtext -> ctx.Sender() <! RequestError errtext; ignored ()
 
         function
-        | UpdateState updater ->
-            become (behavior (updater state) ctx)
-        | FindChannel criteria ->
-            let found = state.channels |> List.tryFind criteria
-            ctx.Sender() <! (found |> function |Some chan -> FoundChannel chan |_ -> RequestError "Not found")
-            ignored state
+        | Terminated(ref, _, _) ->
+            state.channels |> List.tryFind (fun chan -> chan.channelActor = ref) |>
+            function
+            | Some channel ->
+                do state.sessions |> Map.iter(fun _ session -> session.notifySink <! DropChannel channel)
+                become (serverBehavior { state with channels = state.channels |> List.except [channel]} ctx)
+            | _ ->
+                do logger.error (Message.eventX "Failed to locate terminated object: {a}" >> Message.setFieldValue "a" ref)
+                ignored state
 
-        | GetOrCreateChannel name ->
-            state |> ServerApi.addChannel (fun () -> createChannel system) name ""
-            |> replyAndUpdate FoundChannel
+        | :? ServerControlMessage as msg ->
+            match msg with
+            | UpdateState updater ->
+                become (serverBehavior (updater state) ctx)
+            | FindChannel criteria ->
+                let found = state.channels |> List.tryFind criteria
+                ctx.Sender() <! (found |> function |Some chan -> FoundChannel chan |_ -> RequestError "Not found")
+                ignored ()
 
-        | ListChannels criteria ->
-            let found = state.channels |> List.filter criteria
-            ctx.Sender() <! FoundChannels found
-            ignored state
+            | GetOrCreateChannel (name, topic, config) ->
 
-        | StartSession (user, nsink) ->
-            let newState = state |> ServerApi.addSub user nsink
-            become (behavior newState ctx)          
+                let createChannel () =
+                    let actor = createChannelActor ctx config
+                    do logger.debug (Message.eventX "Started watching {a}" >> Message.setFieldValue "a" ref)
+                    monitor ctx actor |> ignore
+                    actor
 
-        | CloseSession userid ->
-            let newState = state |> ServerApi.dropSub userid
-            become (behavior newState ctx)          
+                state
+                    |> Implementation.addChannel createChannel name topic
+                    |> replyAndUpdate FoundChannel
+
+            | ListChannels criteria ->
+                let found = state.channels |> List.filter criteria
+                ctx.Sender() <! FoundChannels found
+                ignored()
+
+            | StartSession (user, nsink) ->
+                do logger.debug (Message.eventX "StartSession user={userId}" >> Message.setFieldValue "userId" user)
+
+                let newState = { state with sessions = state.sessions |> Map.add user { notifySink = nsink } }
+                become (serverBehavior newState ctx)
+
+            | CloseSession userid ->
+                do logger.debug (Message.eventX "CloseSession user={userId}" >> Message.setFieldValue "userId" userid)
+                
+                let newState = { state with sessions = state.sessions |> Map.remove userid }
+                become (serverBehavior newState ctx)          
+        | msg ->
+            do logger.debug (Message.eventX "Failed to process message: {a}" >> Message.setFieldValue "a" msg)
+            unhandled()
     in
-    props <| actorOf2 (behavior { channels = []; sessions = Map.empty }) |> (spawn system "ircserver")
 
-let private getChannelImpl message (server: ServerT) =
-    async {
-        let! (reply: ServerReplyMessage) = server <? message
-        match reply with
-        | FoundChannel channel -> return Ok channel
-        | RequestError error -> return Result.Error error
-        | _ -> return Result.Error "Unknown reason"
-    }
+    spawn system "ircserver" <| props (actorOf2 (serverBehavior initialState)) |> retype
 
 let getChannel criteria =
-    getChannelImpl (FindChannel criteria)
+    Implementation.getChannelImpl (FindChannel criteria)
 
-let getOrCreateChannel name =
-    getChannelImpl (GetOrCreateChannel name)
+let getOrCreateChannel name topic config =
+    Implementation.getChannelImpl (GetOrCreateChannel (name, topic, config))
 
 let listChannels criteria (server: ServerT) =
     async {
@@ -153,21 +176,14 @@ let listChannels criteria (server: ServerT) =
         | _ -> return Result.Error "Unknown error"
     }
 
-let createTestChannels system (server: ServerT) =
-    let addChannel name topic state =
-        match state |> ServerApi.addChannel (fun () -> createChannel system) name topic with
-        | Ok (newstate, _) ->
-            do logger.info (Message.eventX "Added test channel '{name}'" >> Message.setFieldValue "name" name)
-            newstate
-        | Result.Error e ->
-            do logger.error (Message.eventX "Failed to addChannel '{name}': {e}" >> Message.setFieldValue "name" name  >> Message.setFieldValue "e" e)
-            state
-
-    let addChannels =
-        addChannel "Test" "test channel #1"
-        >> addChannel "Weather" "join channel to get updated"
-
-    ignore (server <! UpdateState addChannels)
-
 let startSession (server: ServerT) userId (actor: IActorRef<ServerNotifyMessage>) =
     server <! StartSession (userId, actor)
+
+let addChannel name topic (config: ChannelConfig option) server = async {
+    let! (reply: ServerReplyMessage) = server <? GetOrCreateChannel (name, topic, config |> Option.defaultValue ChannelConfig.Default)
+    return
+        match reply with
+        | FoundChannel channelData -> Ok channelData
+        | RequestError message -> Result.Error message
+        | _ -> Result.Error "Unknown reply"
+}

--- a/test/e2e/Program.fs
+++ b/test/e2e/Program.fs
@@ -4,8 +4,8 @@ open canopy
 [<EntryPoint>]
 let main _ =
 
-    let executingDir () = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)
-    configuration.chromeDir <- "..\\..\\packages\\uitests\\Selenium.WebDriver.ChromeDriver\\driver\\win32"
+    let executingDir = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)
+    configuration.chromeDir <- executingDir
 
     start chrome
 

--- a/test/e2e/Program.fs
+++ b/test/e2e/Program.fs
@@ -14,6 +14,7 @@ let main _ =
     UserCommands.all ()
     NavigationPane.all ()
     InputArea.all()
+    Features.all()
 
     run()
     quit()

--- a/test/e2e/Routines.fs
+++ b/test/e2e/Routines.fs
@@ -1,0 +1,33 @@
+module Routines
+
+open canopy
+
+// Performs server login. Fails if user is already logged out
+let loginAnonymous name =
+    url "http://localhost:8083"
+    onn "http://localhost:8083/logon"
+
+    "#nickname" << name
+
+    click Selectors.loginBtn
+    on "http://localhost:8083/#"
+
+    Selectors.userNick == name
+
+let logout () =
+    url "http://localhost:8083/logoff"
+
+// Switches to existing channel, fails if no such channel exists
+let switchChannel name =
+    click <| Selectors.switchChannel name
+    on "http://localhost:8083/#channel"
+    (element Selectors.selectedChanBtn).Text |> contains name
+
+// Ensures the channel exists (creates if it does not) and switches to this channel
+let joinChannel name =
+    click Selectors.newChannelPlus
+    click Selectors.newChannelInput
+    Selectors.newChannelInput << name
+    press enter
+
+    on "http://localhost:8083/#channel"

--- a/test/e2e/Selectors.fs
+++ b/test/e2e/Selectors.fs
@@ -4,10 +4,12 @@ let messageInputPanel = ".fs-message-input"
 let messageInputText = ".fs-message-input input[type='text']"
 let messageSendBtn = ".fs-message-input .btn:has(> i.mdi-send)"
 
-let switchChannel name = sprintf ".fs-menu button.fs-channel:contains('%s')" name
+let switchChannel name = sprintf ".fs-menu button.fs-channel h1:contains('%s')" name
 let newChannelInput = ".fs-menu input.fs-new-channel"
+let newChannelPlus = ".fs-menu button[title='Create New'] i.mdi-plus"
 
 let selectedChanBtn = ".fs-menu button.selected"
+let menuSwitchChannelTitle = ".fs-menu button.fs-channel h1"
 
 let userNick = ".fs-user #usernick"
 let userStatus = ".fs-user #userstatus"

--- a/test/e2e/e2e.fsproj
+++ b/test/e2e/e2e.fsproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <Compile Include="Selectors.fs" />
+    <Compile Include="Routines.fs" />
     <Compile Include="tests/*.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/test/e2e/e2e.fsproj
+++ b/test/e2e/e2e.fsproj
@@ -17,6 +17,9 @@
     <Content Include="App.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\\..\\packages\\uitests\\Selenium.WebDriver.ChromeDriver\\driver\\win32\*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <Import Project="..\..\.paket\Paket.Restore.targets" />

--- a/test/e2e/tests/Features.fs
+++ b/test/e2e/tests/Features.fs
@@ -27,3 +27,14 @@ let all () =
             |> Expect.all "channel is not removed" ((<>) "MyPersonalChannel")
 
         ()
+
+    "Do not drop channel with autoRemove set to False" &&& fun _ ->
+
+        Routines.joinChannel "Test"
+
+        click Selectors.channelLeaveBtn
+
+        elements Selectors.menuSwitchChannelTitle |> List.map (fun e -> e.Text)
+            |> Expect.contains "newly added channel" "Test"
+
+        ()

--- a/test/e2e/tests/Features.fs
+++ b/test/e2e/tests/Features.fs
@@ -1,0 +1,29 @@
+module Features
+
+open canopy
+open Expecto
+open Expecto.Flip
+
+let all () =
+    context "Miscelaneous features"
+
+    before (fun _ ->
+        Routines.loginAnonymous "Tester2"
+    )
+
+    after (fun _ ->
+        Routines.logout()
+    )
+
+    "Automatically drop channel when last user left" &&& fun _ ->
+
+        Routines.joinChannel "MyPersonalChannel"
+
+        elements Selectors.menuSwitchChannelTitle |> List.map (fun e -> e.Text)
+            |> Expect.contains "newly added channel" "MyPersonalChannel"
+
+        click Selectors.channelLeaveBtn
+        elements Selectors.menuSwitchChannelTitle |> List.map (fun e -> e.Text)
+            |> Expect.all "channel is not removed" ((<>) "MyPersonalChannel")
+
+        ()

--- a/test/e2e/tests/InputArea.fs
+++ b/test/e2e/tests/InputArea.fs
@@ -2,40 +2,28 @@ module InputArea
 
 open canopy
 
-let switchChannel name =
-    click <| Selectors.switchChannel name
-    on "http://localhost:8083/#channel"
-    (element Selectors.selectedChanBtn).Text |> contains name
-
 let all () =
-    context "User console commands"
+    context "Input area tests"
 
     before (fun _ ->
-        url "http://localhost:8083"
-        onn "http://localhost:8083/logon"
-
-        "#nickname" << "InputAreaTester"
-        click Selectors.loginBtn
-        on "http://localhost:8083/#"
-
-        Selectors.userNick == "InputAreaTester"
+        Routines.loginAnonymous "InputAreaTester"
     )
 
     after (fun _ ->
-        url "http://localhost:8083/logoff"
+        Routines.logout()
     )
 
     "Input area is visible in channel view" &&& fun _ ->
 
         notDisplayed Selectors.messageInputPanel
 
-        switchChannel "Test"
+        Routines.switchChannel "Demo"
 
         displayed Selectors.messageInputPanel
 
     "Type and send text, input gets clean" &&& fun _ ->
 
-        switchChannel "Test"
+        Routines.joinChannel "Test"
 
         Selectors.messageInputText << "Hello world"
         Selectors.messageInputText == "Hello world"
@@ -48,22 +36,22 @@ let all () =
 
     "Input message stored per channel" &&& fun _ ->
 
-        switchChannel "Test"
+        Routines.joinChannel "Test"
         Selectors.messageInputText << "test channel"
 
-        switchChannel "Demo"
+        Routines.joinChannel "Demo"
         Selectors.messageInputText == ""
         Selectors.messageInputText << "hi demo"
 
-        switchChannel "Test"
+        Routines.switchChannel "Test"
         Selectors.messageInputText == "test channel"
 
-        switchChannel "Demo"
+        Routines.switchChannel "Demo"
         Selectors.messageInputText == "hi demo"
 
     "Type and send text" &&& fun _ ->
 
-        switchChannel "Test"
+        Routines.joinChannel "Test"
 
         Selectors.messageInputText << "Hello world"
         click Selectors.messageSendBtn

--- a/test/e2e/tests/NavMenu.fs
+++ b/test/e2e/tests/NavMenu.fs
@@ -8,17 +8,11 @@ let all() =
     context "Navigation panel tests"
 
     before (fun _ ->
-        url "http://localhost:8083"
-        onn "http://localhost:8083/logon"
-
-        "#nickname" << "Tester-tester"
-
-        click Selectors.loginBtn
-        on "http://localhost:8083/#"
+        Routines.loginAnonymous "Tester-tester"
     )
 
     after (fun _ ->
-        url "http://localhost:8083/logoff"
+        Routines.logout ()
     )
 
     "About link" &&& fun _ ->
@@ -55,7 +49,7 @@ let all() =
         sleep()
         0 === (height Selectors.newChannelInput)
         
-        click ".fs-menu button[title='Create New'] i.mdi-plus"
+        click Selectors.newChannelPlus
         sleep()
 
         Expect.isGreaterThan (height Selectors.newChannelInput) 30 "input is visible"
@@ -70,14 +64,14 @@ let all() =
 
     "Select channel" &&& fun _ ->
 
-        click <| Selectors.switchChannel "Demo"
-        click <| Selectors.switchChannel "Test"
+        Routines.joinChannel "Demo"
+        Routines.joinChannel "Test"
 
         // ensure there a title and input area
         sleep()
         (element Selectors.selectedChanBtn).Text |> contains "Test"
         
-        click <| Selectors.switchChannel "Demo"
+        Routines.switchChannel "Demo"
 
         sleep()
         (element Selectors.selectedChanBtn).Text |> contains "Demo"

--- a/test/e2e/tests/UserCommands.fs
+++ b/test/e2e/tests/UserCommands.fs
@@ -23,7 +23,11 @@ let all () =
         Selectors.userStatus == ""
 
         // activate channel for command input bar to appear (not nice thing)
-        click <| Selectors.switchChannel "Test"
+        click Selectors.newChannelPlus
+        click Selectors.newChannelInput
+        Selectors.newChannelInput << "Test"
+        press enter
+
         on "http://localhost:8083/#channel"
     )
 


### PR DESCRIPTION
This PR changes default channel behavior so that it gets automatically shut down after last user exits the channel. There's new (config: ChannelConfig) parameter to create channel API. Pre-defined channels won't be automatically removed because there's a bot user constantly sitting in Demo channel, while Test channel got config.autoRemove set to false.

This PR also improves the way e2e project references chromedriver.exe so that it's now copied to output directory and webdriver config does not use relative paths to chromedriver package anymore. As a result Ionide's Expecto test runner is now functional!